### PR TITLE
Create SVG to illustrate heroku pipeline deploy workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ grunt release[:patch | :minor | :major]
 heroku pipeline:promote
 ```
 
+![Hubot deploy pipeline](https://rawgithub.com/gittip/roobot/1-create-svg/docs/hubot-deploy-workflow.svg)
+
 ### Scripting
 
 Take a look at the scripts in the `./scripts` folder for examples.

--- a/docs/hubot-deploy-workflow.svg
+++ b/docs/hubot-deploy-workflow.svg
@@ -1,0 +1,437 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="800"
+   height="400"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.2 r9819"
+   sodipodi:docname="hubot-deploy-workflow.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="TriangleOutS"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutS"
+       style="overflow:visible">
+      <path
+         id="path4420"
+         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="scale(0.2,0.2)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM"
+       style="overflow:visible">
+      <path
+         id="path4417"
+         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="scale(0.4,0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutL"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutL"
+       style="overflow:visible">
+      <path
+         id="path4414"
+         d="m 5.77,0 -8.65,5 0,-10 8.65,5 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="scale(0.8,0.8)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend"
+       style="overflow:visible">
+      <path
+         id="path4298"
+         style="font-size:12px;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend"
+       style="overflow:visible">
+      <path
+         id="path4292"
+         style="font-size:12px;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart"
+       style="overflow:visible">
+      <path
+         id="path4271"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend"
+       style="overflow:visible">
+      <path
+         id="path4274"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;marker-start:none"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <linearGradient
+       id="linearGradient3836">
+      <stop
+         style="stop-color:#3b2f63;stop-opacity:1;"
+         offset="0"
+         id="stop3838" />
+      <stop
+         style="stop-color:#794aa2;stop-opacity:1;"
+         offset="1"
+         id="stop3840" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3836"
+       id="linearGradient3842"
+       x1="-6.4822621"
+       y1="200.34631"
+       x2="632.02063"
+       y2="200.34631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.294695,0,0,0.15527952,-5.8684249,344.10867)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.62875"
+     inkscape:cx="231.15714"
+     inkscape:cy="82.81633"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     inkscape:window-width="1434"
+     inkscape:window-height="737"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer">
+    <rect
+       style="fill:url(#linearGradient3842);fill-opacity:1;stroke:none"
+       id="rect3826"
+       width="826.66644"
+       height="64.822639"
+       x="-14.260977"
+       y="342.80704" />
+    <rect
+       style="opacity:0.98999999000000005;fill:none;stroke:#000000;stroke-width:5;stroke-linejoin:miter;stroke-miterlimit:20;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3867"
+       width="799.38599"
+       height="400.92093"
+       x="0.61396748"
+       y="0.30698422" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-652.36218)">
+    <path
+       sodipodi:type="star"
+       style="opacity:0.98999999;fill:#ccbcde;fill-opacity:1;fill-rule:evenodd;stroke:#a98bc3;stroke-width:10;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-start:none;marker-end:none"
+       id="path3012"
+       sodipodi:sides="6"
+       sodipodi:cx="106.95733"
+       sodipodi:cy="110.24287"
+       sodipodi:r1="84.920113"
+       sodipodi:r2="73.542976"
+       sodipodi:arg1="1.5631629"
+       sodipodi:arg2="2.0867617"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="M 107.60555,195.16051 33.740609,153.26307 33.092384,68.345427 106.3091,25.325228 l 73.86495,41.89744 0.64822,84.917642 z"
+       transform="translate(127.95239,667.47068)" />
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+       x="234.46957"
+       y="785.91522"
+       id="text3822"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3824"
+         x="234.46957"
+         y="785.91522"
+         style="font-size:22px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;text-anchor:middle;font-family:Helvetica;-inkscape-font-specification:Helvetica">roobot-test</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+       x="107.87711"
+       y="916.81927"
+       id="text7996"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         x="107.87711"
+         y="916.81927"
+         id="tspan8000"
+         style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;writing-mode:lr-tb;text-anchor:end;fill:#969696;fill-opacity:1;font-family:Helvetica;-inkscape-font-specification:Helvetica">IRC</tspan><tspan
+         sodipodi:role="line"
+         x="107.87711"
+         y="936.81927"
+         id="tspan8004"
+         style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;writing-mode:lr-tb;text-anchor:end;fill:#969696;fill-opacity:1;font-family:Helvetica;-inkscape-font-specification:Helvetica">bot name</tspan><tspan
+         sodipodi:role="line"
+         x="107.87711"
+         y="956.81927"
+         id="tspan8006"
+         style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;writing-mode:lr-tb;text-anchor:end;fill:#969696;fill-opacity:1;font-family:Helvetica;-inkscape-font-specification:Helvetica">git url</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+       x="234.60211"
+       y="916.9599"
+       id="text8008"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan8010"
+         x="234.60211"
+         y="916.9599"
+         style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;writing-mode:lr-tb;text-anchor:middle;font-family:Helvetica;-inkscape-font-specification:Helvetica">#gittip-hubot-test</tspan><tspan
+         sodipodi:role="line"
+         x="234.60211"
+         y="936.9599"
+         id="tspan8012"
+         style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;writing-mode:lr-tb;text-anchor:middle;font-family:Helvetica;-inkscape-font-specification:Helvetica">roobot-test</tspan><tspan
+         sodipodi:role="line"
+         x="234.60211"
+         y="956.9599"
+         id="tspan8014"
+         style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;writing-mode:lr-tb;text-anchor:middle;font-family:Helvetica;-inkscape-font-specification:Helvetica">git@heroku:roobot-test.git</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+       x="650.70367"
+       y="916.9599"
+       id="text8044"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan8046"
+         x="650.70367"
+         y="916.9599"
+         style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;writing-mode:lr-tb;text-anchor:middle;font-family:Helvetica;-inkscape-font-specification:Helvetica">#gittip</tspan><tspan
+         sodipodi:role="line"
+         x="650.70367"
+         y="936.9599"
+         id="tspan8048"
+         style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;writing-mode:lr-tb;text-anchor:middle;font-family:Helvetica;-inkscape-font-specification:Helvetica">roobot</tspan><tspan
+         sodipodi:role="line"
+         x="650.70367"
+         y="956.9599"
+         id="tspan8050"
+         style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;writing-mode:lr-tb;text-anchor:middle;font-family:Helvetica;-inkscape-font-specification:Helvetica">git@heroku:roobot-prod.git</tspan></text>
+  </g>
+  <g
+     transform="translate(0,-652.36218)"
+     id="g4230"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1 copy"
+     style="display:inline">
+    <flowRoot
+       transform="translate(0,652.36218)"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Helvetica"
+       id="flowRoot4234"
+       xml:space="preserve"><flowRegion
+         id="flowRegion4236"><rect
+           y="83.665596"
+           x="62.877945"
+           height="43.431156"
+           width="115.38427"
+           id="rect4238" /></flowRegion><flowPara
+         id="flowPara4240">prro</flowPara></flowRoot>    <text
+       transform="translate(0,652.36218)"
+       sodipodi:linespacing="125%"
+       id="text4242"
+       y="100.51948"
+       x="112.14314"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+         y="100.51948"
+         x="112.14314"
+         id="tspan4244"
+         sodipodi:role="line" /></text>
+    <text
+       transform="translate(0,652.36218)"
+       sodipodi:linespacing="125%"
+       id="text4246"
+       y="84.313828"
+       x="86.214088"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+       xml:space="preserve"><tspan
+         y="84.313828"
+         x="86.214088"
+         id="tspan4248"
+         sodipodi:role="line" /></text>
+    <text
+       transform="translate(0,652.36218)"
+       sodipodi:linespacing="125%"
+       id="text4250"
+       y="107.64997"
+       x="95.937485"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Serif;-inkscape-font-specification:Serif"
+       xml:space="preserve"><tspan
+         y="107.64997"
+         x="95.937485"
+         id="tspan4252"
+         sodipodi:role="line" /></text>
+    <text
+       transform="translate(0,652.36218)"
+       sodipodi:linespacing="125%"
+       id="text4254"
+       y="122.55917"
+       x="86.214088"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Serif;-inkscape-font-specification:Serif"
+       xml:space="preserve"><tspan
+         y="122.55917"
+         x="86.214088"
+         id="tspan4256"
+         sodipodi:role="line" /></text>
+    <text
+       transform="translate(0,652.36218)"
+       sodipodi:linespacing="125%"
+       id="text4258"
+       y="110.8911"
+       x="109.55023"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+       xml:space="preserve"><tspan
+         y="110.8911"
+         x="109.55023"
+         id="tspan4260"
+         sodipodi:role="line" /></text>
+    <path
+       transform="translate(544.05395,667.47068)"
+       d="M 107.60555,195.16051 33.740609,153.26307 33.092384,68.345427 106.3091,25.325228 l 73.86495,41.89744 0.64822,84.917642 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0"
+       inkscape:flatsided="true"
+       sodipodi:arg2="2.0867617"
+       sodipodi:arg1="1.5631629"
+       sodipodi:r2="73.542976"
+       sodipodi:r1="84.920113"
+       sodipodi:cy="110.24287"
+       sodipodi:cx="106.95733"
+       sodipodi:sides="6"
+       id="path4232"
+       style="opacity:0.98999999;fill:#ccbcde;fill-opacity:1;fill-rule:evenodd;stroke:#a98bc3;stroke-width:10;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-start:none;marker-end:none"
+       sodipodi:type="star" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4262"
+       y="785.91522"
+       x="651.35455"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+       xml:space="preserve"><tspan
+         style="font-size:22px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;writing-mode:lr-tb;text-anchor:middle;font-family:Helvetica;-inkscape-font-specification:Helvetica"
+         y="785.91522"
+         x="651.35455"
+         id="tspan4264"
+         sodipodi:role="line">roobot-prod</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Text">
+    <path
+       style="fill:none;stroke:#d3d5d5;stroke-width:8;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker-mid:none;marker-end:none"
+       d="m 319.54304,125.35137 233.77567,0"
+       id="path4266"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.98999999;fill:#d3d5d5;fill-opacity:1;stroke:none"
+       id="path7964"
+       sodipodi:sides="3"
+       sodipodi:cx="359.87329"
+       sodipodi:cy="137.06441"
+       sodipodi:r1="13.706425"
+       sodipodi:r2="6.8532128"
+       sodipodi:arg1="-2.0943951"
+       sodipodi:arg2="-1.0471976"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 353.02008,125.1943 20.55964,11.87011 -20.55964,11.87011 z"
+       transform="matrix(1.2669948,0,0,1.2669948,95.99749,-48.308519)"
+       inkscape:transform-center-x="-4.3414877" />
+    <text
+       xml:space="preserve"
+       style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:Liberation Mono;-inkscape-font-specification:Liberation Mono"
+       x="436.23672"
+       y="114.82433"
+       id="text9828"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan9830"
+         x="436.23672"
+         y="114.82433"
+         style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;writing-mode:lr-tb;text-anchor:middle;font-family:Courier;-inkscape-font-specification:Courier">`heroku pipeline:promote`</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
We're using the heroku labs pipeline plugin:
https://devcenter.heroku.com/articles/labs-pipelines#enable-pipelines

To feel comfortable deploying (for people who aren't me), we need a good visual reference for how deploy works, including commands to push slugs through the pipeline, how envvars change between environments, and which irc #channels the testbot appears in.

Here's to how render an SVG from the project in a markdown file (thanks @rgrove!):
https://rawgithub.com/
