### PR TITLE
Add script for getting freshdesk stats

### DIFF
--- a/scripts/freshdesk-stats.coffee
+++ b/scripts/freshdesk-stats.coffee
@@ -1,0 +1,29 @@
+# Description:
+#   List stats for Freshdesk support.
+#
+# Commands:
+#   hubot freshdesk - Reply with support ticket stats.
+#
+# Configuration:
+#   HUBOT_FRESHDESK_APIKEY
+#   HUBOT_FRESHDESK_PROJECT
+
+config =
+  api_key: process.env.HUBOT_FRESHDESK_APIKEY
+  project: process.env.HUBOT_FRESHDESK_PROJECT
+
+endpoint = "#{config.project}.freshdesk.com"
+uri = "helpdesk/tickets"
+response_type = "json"
+
+module.exports = (robot) ->
+  robot.respond /freshdesk$/i, (msg) ->
+    robot.http("https://#{config.api_key}:x@#{endpoint}/#{uri}.#{response_type}")
+      .get() (err, res, body) ->
+        open_count = 0
+
+        issues = JSON.parse body
+        for issue in issues
+          open_count++ if issue.status_name.match /open/i
+
+        msg.send "Open support tickets: #{open_count}"


### PR DESCRIPTION
Spin-off from https://github.com/gittip/www.gittip.com/issues/2110

http://freshdesk.com/api

Just thinking that it would be great to give some sort of introspection into the health of the support queue from chat. Not sure how that would work yet: listing stats, or listing actual ticket subjects. (I'm unsure what the final decision on privacy of tickets was.)
### Sample interaction

```
<patcon> roobot-test: freshdesk
<roobot-test> Open support tickets: 24
```
